### PR TITLE
Title: check general H1 before checking H2 within siblings

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -375,15 +375,16 @@ function getArticleTitle() {
     // Check to see if there's a h1 within the previous sibling of the article
     if(!text)
         text = checkHeading(globalMostPs.previousElementSibling, 'h1');
+    // Check to see if there's a h1 more generally
+    if(!text)
+        if(document.body.querySelector('h1'))
+            text = document.body.querySelector('h1').innerText;
+  
     // Check to see if there's a h2 within the previous sibling of the article
     if(!text)
         text = checkHeading(globalMostPs.previousElementSibling, 'h2');
 
     if(!text) {
-        // Check to see if there's a h1 more generally
-        if(document.body.querySelector('h1'))
-            return document.body.querySelector('h1').innerText;
-
         // Check to see if there's a h2 more generally
         if(document.body.querySelector('h2'))
             return document.body.querySelector('h2').innerText;


### PR DESCRIPTION
I think you should check for general `h1`s before you check for `h2`s within siblings when getting a title. If a page has a general `h1` but `h2`s are found first within the siblings, you end up with something else as a title more quickly.

This fixes titles on Wikipedia for instance.